### PR TITLE
feat: use Ipapi API to get geolocation data

### DIFF
--- a/src/services/ipGeolocationApi.ts
+++ b/src/services/ipGeolocationApi.ts
@@ -26,18 +26,23 @@ export const callGeolocationApi = async (
 
   const {
     ip,
-    location: { city, region, lat, lng, postalCode, timezone },
-    isp,
+    city,
+    org,
+    latitude,
+    longitude,
+    postal,
+    region_code,
+    utc_offset,
   } = response.data;
 
   return {
     ip,
     city,
-    region,
-    lat,
-    lng,
-    postalCode,
-    timezone,
-    isp,
+    region: region_code,
+    lat: latitude,
+    lng: longitude,
+    postalCode: postal,
+    timezone: utc_offset,
+    isp: org,
   };
 };

--- a/src/services/ipGeolocationApi.ts
+++ b/src/services/ipGeolocationApi.ts
@@ -16,7 +16,7 @@ export const callGeolocationApi = async (
   ipAddress?: string
 ): Promise<ApiResponse> => {
   const response = await axios.get<IpapiResponse>(
-    'https://ipapi.co/json'
+    `https://ipapi.co/${ipAddress ? ipAddress + '/' : ''}json/`
   );
 
   const {

--- a/src/services/ipGeolocationApi.ts
+++ b/src/services/ipGeolocationApi.ts
@@ -2,24 +2,14 @@ import { ApiResponse } from '@/types/types';
 import axios from 'axios';
 
 interface IpapiResponse {
-  ip: '208.67.222.222';
-  city: 'San Francisco';
-  region: 'California';
+  ip: '8.8.8.8';
+  city: 'Mountain View';
   region_code: 'CA';
-  country: 'US';
-  country_name: 'United States';
-  continent_code: 'NA';
-  in_eu: false;
-  postal: '94107';
-  latitude: 37.7697;
-  longitude: -122.3933;
-  timezone: 'America/Los_Angeles';
+  postal: '94035';
+  latitude: 37.386;
+  longitude: -122.0838;
   utc_offset: '-0800';
-  country_calling_code: '+1';
-  currency: 'USD';
-  languages: 'en-US,es-US,haw,fr';
-  asn: 'AS36692';
-  org: 'OpenDNS, LLC';
+  org: 'Google LLC';
 }
 
 export const callGeolocationApi = async (

--- a/src/services/ipGeolocationApi.ts
+++ b/src/services/ipGeolocationApi.ts
@@ -16,7 +16,7 @@ export const callGeolocationApi = async (
   ipAddress?: string
 ): Promise<ApiResponse> => {
   const response = await axios.get<IpapiResponse>(
-    'https://geo.ipify.org/api/v2/country,city'
+    'https://ipapi.co/json'
   );
 
   const {

--- a/src/services/ipGeolocationApi.ts
+++ b/src/services/ipGeolocationApi.ts
@@ -1,33 +1,31 @@
 import { ApiResponse } from '@/types/types';
 import axios from 'axios';
 
-interface IpifyResponse {
-  ip: string;
-  location: {
-    country: string;
-    region: string;
-    city: string;
-    lat: number;
-    lng: number;
-    postalCode: string;
-    timezone: string;
-    geonameId: number;
-  };
-  domains: string[];
-  as: {
-    asn: number;
-    name: string;
-    route: string;
-    domain: string;
-    type: string;
-  };
-  isp: string;
+interface IpapiResponse {
+  ip: '208.67.222.222';
+  city: 'San Francisco';
+  region: 'California';
+  region_code: 'CA';
+  country: 'US';
+  country_name: 'United States';
+  continent_code: 'NA';
+  in_eu: false;
+  postal: '94107';
+  latitude: 37.7697;
+  longitude: -122.3933;
+  timezone: 'America/Los_Angeles';
+  utc_offset: '-0800';
+  country_calling_code: '+1';
+  currency: 'USD';
+  languages: 'en-US,es-US,haw,fr';
+  asn: 'AS36692';
+  org: 'OpenDNS, LLC';
 }
 
 export const callGeolocationApi = async (
   ipAddress?: string
 ): Promise<ApiResponse> => {
-  const response = await axios.get<IpifyResponse>(
+  const response = await axios.get<IpapiResponse>(
     'https://geo.ipify.org/api/v2/country,city',
     {
       params: ipAddress

--- a/src/services/ipGeolocationApi.ts
+++ b/src/services/ipGeolocationApi.ts
@@ -16,12 +16,7 @@ export const callGeolocationApi = async (
   ipAddress?: string
 ): Promise<ApiResponse> => {
   const response = await axios.get<IpapiResponse>(
-    'https://geo.ipify.org/api/v2/country,city',
-    {
-      params: ipAddress
-        ? { apiKey: process.env.VUE_APP_IPIFY_API_KEY, ipAddress }
-        : { apiKey: process.env.VUE_APP_IPIFY_API_KEY },
-    }
+    'https://geo.ipify.org/api/v2/country,city'
   );
 
   const {

--- a/src/utils/useGeoApi.ts
+++ b/src/utils/useGeoApi.ts
@@ -1,12 +1,12 @@
 import { Map } from 'leaflet';
 import { ApiResponse } from '@/types/types';
-import { mockApiCall } from '@/utils/mockApiCall';
 import { createMap } from './createMap';
+import { callGeolocationApi } from '@/services/ipGeolocationApi';
 
 export const useGeoApi = async (
   ipAddress?: string
 ): Promise<{ response: ApiResponse; leafletMap: Map }> => {
-  const response = await mockApiCall(ipAddress);
+  const response = await callGeolocationApi(ipAddress);
 
   const { lng, lat } = response;
 


### PR DESCRIPTION
Man I found this really cool API that does the same thing that Ipify but free and without API key!!!

Things that need to be done:

- [x] Change the APIResponse interface
- [x] Change the URL
- [x] Remove the params
- [x] Use the actual API instead of the mock API

Any changes will be done in another PR!